### PR TITLE
Minor markup fixes for a11y

### DIFF
--- a/site-resources/demo.tpl.html
+++ b/site-resources/demo.tpl.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<html lang="en">
 <p>
   <a href="?nojs">Load without JavaScript</a>
   <a href="?">Load with JavaScript</a>
@@ -34,3 +35,4 @@
   window.addEventListener('message', sendSize);
   sendSize();
 </script>
+</html>

--- a/site-resources/element.tpl.html
+++ b/site-resources/element.tpl.html
@@ -22,9 +22,9 @@ limitations under the License.
   {{=it.intro}}
 </section>
 <h2>Demo</h2>
-<iframe src="{{=it.title}}_demo.html" class="demo" aria-label="live demo" role="section"></iframe>
+<iframe src="{{=it.title}}_demo.html" class="demo" aria-label="live demo" role="region"></iframe>
 <h2>Example usage</h2>
-<ul class="literate demo" id="{{=it.title}}">
+<ul class="literate demo" id="{{=it.title}}_demo">
   {{ for (let section of it.demoSections) { }}
   <li class="{{=section.commentType.toLowerCase()}}">
     <aside class="{{? section.commentText.length <= 0}}empty{{?}}">{{=section.commentText}}</aside>
@@ -33,7 +33,7 @@ limitations under the License.
   {{ } }}
 </ul>
 <h2>Code</h2>
-<ul class="literate code" id="{{=it.title}}">
+<ul class="literate code" id="{{=it.title}}_impl">
   {{ for (let section of it.sections) { }}
   <li class="{{=section.commentType.toLowerCase()}}">
     <aside class="{{? section.commentText.length <= 0}}empty{{?}}">{{=section.commentText}}</aside>

--- a/site-resources/element.tpl.html
+++ b/site-resources/element.tpl.html
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <!doctype html>
+<html lang="en">
 <title>Dash Elements – {{=it.title}}</title>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
@@ -21,7 +22,7 @@ limitations under the License.
   {{=it.intro}}
 </section>
 <h2>Demo</h2>
-<iframe src="{{=it.title}}_demo.html" class="demo"></iframe>
+<iframe src="{{=it.title}}_demo.html" class="demo" aria-label="live demo" role="section"></iframe>
 <h2>Example usage</h2>
 <ul class="literate demo" id="{{=it.title}}">
   {{ for (let section of it.demoSections) { }}
@@ -41,3 +42,4 @@ limitations under the License.
   {{ } }}
 </ul>
 <script src="scripts/bootstrap.js" defer></script>
+</html>

--- a/site-resources/index.tpl.html
+++ b/site-resources/index.tpl.html
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <!doctype html>
+<html lang="en">
 <title>Dash Elements</title>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
@@ -23,3 +24,4 @@ limitations under the License.
     {{ } }}
 </ul>
 <script src="scripts/bootstrap.js" defer></script>
+</html>


### PR DESCRIPTION
[TIL](https://twitter.com/DasSurma/status/834713623851302912) that the `lang` attribute on `<html>` is important, so I fixed that.

I also did a pass with a screen reader on the current site and noticed that demo feels awkward. Tried to improve it, please double-check I’m not doing anything dumb here, @robdodson 😅 

The code section feels awkward, too, but I’m not sure how to address that. 